### PR TITLE
個人、全体の対戦履歴取得APIにレコードのトータル件数を取得するようにコード修正

### DIFF
--- a/backend/app/Http/Controllers/PlayerController.php
+++ b/backend/app/Http/Controllers/PlayerController.php
@@ -14,7 +14,7 @@ use App\Http\Requests\Game\GameHistoryListRequest;
 use Package\Usecase\Player\ListHistory\PlayerListHistoryServiceInterface;
 use Package\Usecase\Player\PlayerList\PlayerListServiceInterface;
 use Package\Usecase\Game\GameRecord\GetList\GameRecordListByDateRangeServiceInterface;
-use Package\Usecase\Player\GetProfile\PlayerListProfileServiceInterface;
+use Package\Usecase\Player\GetProfile\PlayerGetProfileServiceInterface;
 
 class PlayerController extends Controller
 {

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -70,7 +70,7 @@ class UserSeeder extends Seeder
         $faker = FakerFactory::create();
         $index = UserModel::count();
         // ここからダミーデータ
-        for ($i = 1; $i < 20; $i++) {
+        for ($i = 1; $i < 10; $i++) {
             UserModel::create([
                 'player_id'         => $index + $i,
                 'role_id'           => mt_rand(1, 3),

--- a/backend/package/Application/Game/GameHistory/GetList/GameHistoryListService.php
+++ b/backend/package/Application/Game/GameHistory/GetList/GameHistoryListService.php
@@ -33,6 +33,8 @@ class GameHistoryListService implements GameHistoryListServiceInterface {
 			$paginator, $beginDate, $endDate
 		);
 
-		return new GameHistoryListData($gameRecords);
+		$gameRecordTotalCount = $this->gameRecordRepository->listHistoryByDateRangeCount($beginDate, $endDate);
+
+		return new GameHistoryListData($gameRecords, $gameRecordTotalCount);
 	}
 }

--- a/backend/package/Application/Player/ListHistory/PlayerListHistoryService.php
+++ b/backend/package/Application/Player/ListHistory/PlayerListHistoryService.php
@@ -47,6 +47,10 @@ class PlayerListHistoryService implements PlayerListHistoryServiceInterface {
 			$user, $paginator, $beginDate, $endDate
 		);
 
-		return new PlayerListHistoryData($gameRecords);
+		$gameRecordTotalCount = $this->gameRecordRepository->listHistoryByUserWithDateRangeCount(
+			$user, $beginDate, $endDate
+		);
+
+		return new PlayerListHistoryData($gameRecords, $gameRecordTotalCount);
 	}
 }

--- a/backend/package/Domain/Game/Repository/GameRecordRepositoryInterface.php
+++ b/backend/package/Domain/Game/Repository/GameRecordRepositoryInterface.php
@@ -27,6 +27,14 @@ interface GameRecordRepositoryInterface
     public function listHistoryByDateRange(Paginator $paginator, Date $beginDate, Date $endDate): array;
 
     /**
+    * 対戦履歴を日付範囲で取得し、総件数を返す
+    * @param Date $beginDate
+    * @param Date $endDate
+    * @return int
+    */
+    public function listHistoryByDateRangeCount(Date $beginDate, Date $endDate): int;
+
+    /**
     * 特定ユーザの対戦履歴を日付範囲で取得する
     * @param User $user
     * @param Paginator $paginator
@@ -35,4 +43,13 @@ interface GameRecordRepositoryInterface
     * @return array<GamePlayerRecord>
     */
     public function listHistoryByUserWithDateRange(User $user, Paginator $paginator, Date $beginDate, Date $endDate): array;
+
+    /**
+    * 特定ユーザの対戦履歴を日付範囲で取得し、総件数を返す
+    * @param User $user
+    * @param Date $beginDate
+    * @param Date $endDate
+    * @return int
+    */
+    public function listHistoryByUserWithDateRangeCount(User $user, Date $beginDate, Date $endDate): int;
 }

--- a/backend/package/Infrastructure/Eloquent/Game/GameRecordRepository.php
+++ b/backend/package/Infrastructure/Eloquent/Game/GameRecordRepository.php
@@ -99,6 +99,20 @@ class GameRecordRepository implements GameRecordRepositoryInterface
     }
 
     /**
+    * 対戦履歴を日付範囲で取得し、総件数を返す
+    * @param Date $beginDate
+    * @param Date $endDate
+    * @return int
+    */
+    public function listHistoryByDateRangeCount(Date $beginDate, Date $endDate): int
+    {
+        $count = EloquentGameRecordModel::whereStartedAtByDateRange($beginDate, $endDate)
+        ->count();
+
+        return $count;
+    }
+
+    /**
     * 特定ユーザの対戦履歴を日付範囲で取得する
     * @param User $user
     * @param Paginator $paginator
@@ -132,6 +146,22 @@ class GameRecordRepository implements GameRecordRepositoryInterface
         }
 
         return $results;
+    }
+
+    /**
+    * 特定ユーザの対戦履歴を日付範囲で取得し、総件数を返す
+    * @param User $user
+    * @param Date $beginDate
+    * @param Date $endDate
+    * @return int
+    */
+    public function listHistoryByUserWithDateRangeCount(User $user, Date $beginDate, Date $endDate): int
+    {
+        $count = EloquentGameRecordModel::whereStartedAtByDateRange($beginDate, $endDate)
+        ->whereHasByPlayerMemory($user->getPlayer()->getPlayerId())
+        ->count();
+
+        return $count;
     }
 
     /**************************************************

--- a/backend/package/Usecase/Game/GameHistory/GetList/GameHistoryListData.php
+++ b/backend/package/Usecase/Game/GameHistory/GetList/GameHistoryListData.php
@@ -6,8 +6,9 @@ use Package\Usecase\Data;
 
 class GameHistoryListData extends Data {
   public $gameHistories;
+  public $gameHistoryTotalCount;
 
-  public function __construct(array $sources)
+  public function __construct(array $sources, int $count)
   {
     $response = [];
     foreach ($sources as $source) {
@@ -27,6 +28,7 @@ class GameHistoryListData extends Data {
     }
 
     $this->gameHistories = $response;
+    $this->gameHistoryTotalCount = $count;
   }
 
   private function toPlayerMemories(array $sources): array

--- a/backend/package/Usecase/Player/ListHistory/PlayerListHistoryData.php
+++ b/backend/package/Usecase/Player/ListHistory/PlayerListHistoryData.php
@@ -10,8 +10,9 @@ use Package\Usecase\Data;
 class PlayerListHistoryData extends Data
 {
 	public $playerHistories;
+	public $playerHistoryTotalCount;
 
-	public function __construct($sources)
+	public function __construct(array $sources, int $count)
 	{
 		$response = [];
 		foreach ($sources as $source) {
@@ -31,6 +32,7 @@ class PlayerListHistoryData extends Data
 		}
 
 		$this->playerHistories = $response;
+		$this->playerHistoryTotalCount = $count;
 	}
 
 	private function toPlayerMemories(array $playerMemories): array

--- a/backend/routes/Api/Unauthenticated/AuthRoutes.php
+++ b/backend/routes/Api/Unauthenticated/AuthRoutes.php
@@ -4,6 +4,7 @@ namespace Routes\Api\Unauthenticated;
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\AccountController;
 
 class AuthRoutes {
 	public static function routes()

--- a/infra/docker/swagger/api.yaml
+++ b/infra/docker/swagger/api.yaml
@@ -161,7 +161,8 @@ paths:
                       "startedAt": "2021-12-20 15:02:00",
                       "finishedAt": null
                     }
-                  ]
+                  ],
+                  gameHistoryTotalCount: 222
                 }
   "/api/player/history/{userId}":
     get:
@@ -320,5 +321,6 @@ paths:
                       "startedAt": "2021-12-20 15:02:00",
                       "finishedAt": "2021-12-20 15:02:10"
                     }
-                  ]
+                  ],
+                  playerHistoryTotalCount: 122
                 }


### PR DESCRIPTION
## 修正内容
- 表題の通り

## 経緯
<img width="874" alt="スクリーンショット 0003-07-10 17 05 07" src="https://user-images.githubusercontent.com/46346954/125156556-05e7e580-e1a1-11eb-9161-a0d4b4a94f5f.png">
