### PR TITLE
ApiPaginatorの実装

### DIFF
--- a/backend/package/Application/Game/GameHistory/GetList/GameHistoryListService.php
+++ b/backend/package/Application/Game/GameHistory/GetList/GameHistoryListService.php
@@ -10,6 +10,7 @@ use Package\Domain\System\Entity\Paginator;
 use Package\Domain\System\ValueObject\Date;
 use Package\Domain\System\ValueObject\Offset;
 use Package\Domain\System\ValueObject\Limit;
+use Package\Domain\System\Entity\ApiPaginator;
 
 class GameHistoryListService implements GameHistoryListServiceInterface {
     private $gameRecordRepository;
@@ -35,6 +36,12 @@ class GameHistoryListService implements GameHistoryListServiceInterface {
 
 		$gameRecordTotalCount = $this->gameRecordRepository->listHistoryByDateRangeCount($beginDate, $endDate);
 
-		return new GameHistoryListData($gameRecords, $gameRecordTotalCount);
+		$apiPaginator = new ApiPaginator([
+			'currentPage' 	=> $command->page,
+			'totalCount' 	=> $gameRecordTotalCount,
+			'limit' 		=> $command->limit,
+		]);
+
+		return new GameHistoryListData($gameRecords, $apiPaginator);
 	}
 }

--- a/backend/package/Application/Player/ListHistory/PlayerListHistoryService.php
+++ b/backend/package/Application/Player/ListHistory/PlayerListHistoryService.php
@@ -12,6 +12,7 @@ use Package\Domain\System\Entity\Paginator;
 use Package\Domain\System\ValueObject\Date;
 use Package\Domain\System\ValueObject\Offset;
 use Package\Domain\System\ValueObject\Limit;
+use Package\Domain\System\Entity\ApiPaginator;
 
 class PlayerListHistoryService implements PlayerListHistoryServiceInterface {
 	private $userRepository;
@@ -51,6 +52,12 @@ class PlayerListHistoryService implements PlayerListHistoryServiceInterface {
 			$user, $beginDate, $endDate
 		);
 
-		return new PlayerListHistoryData($gameRecords, $gameRecordTotalCount);
+		$apiPaginator = new ApiPaginator([
+			'currentPage' 	=> $command->page,
+			'totalCount' 	=> $gameRecordTotalCount,
+			'limit' 		=> $command->limit,
+		]);
+
+		return new PlayerListHistoryData($gameRecords, $apiPaginator);
 	}
 }

--- a/backend/package/Domain/System/Entity/ApiPaginator.php
+++ b/backend/package/Domain/System/Entity/ApiPaginator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Package\Domain\System\Entity;
+
+use Package\Domain\Resource;
+
+class ApiPaginator extends Resource {
+	protected $currentPage;
+	protected $totalCount;
+	protected $limit;
+
+	public function __construct($data)
+	{
+		parent::__construct($data);
+	}
+
+	public function getPrefPage(): int
+	{
+		return $this->getCurrentPage() > 1 ? $this->getCurrentPage() - 1 : 1;
+	}
+
+	public function getCurrentPage(): int
+	{
+		return $this->currentPage >= 1 ? $this->currentPage : 1;
+	}
+
+	public function getNextPage(): int
+	{
+		return $this->getCurrentPage() < $this->getTotalPage() ? $this->getCurrentPage() + 1 : $this->getTotalPage();
+	}
+
+	public function getTotalCount(): int
+	{
+		return $this->totalCount;
+	}
+
+	public function getTotalPage(): int
+	{
+		return ceil($this->totalCount/$this->limit);
+	}
+
+	public function getLimit(): int
+	{
+		return $this->limit;
+	}
+
+	public function getPaginator()
+	{
+		return (object) [
+			'pref' 			=> $this->getPrefPage(),
+			'current' 		=> $this->getCurrentPage(),
+			'next' 			=> $this->getNextPage(),
+			'totalCount' 	=> $this->getTotalCount(),
+			'totalPage' 	=> $this->getTotalPage(),
+			'limit' 		=> $this->getLimit(),
+		];
+	}
+}

--- a/backend/package/Usecase/Game/GameHistory/GetList/GameHistoryListData.php
+++ b/backend/package/Usecase/Game/GameHistory/GetList/GameHistoryListData.php
@@ -3,12 +3,13 @@
 namespace Package\Usecase\Game\GameHistory\GetList;
 
 use Package\Usecase\Data;
+use Package\Domain\System\Entity\ApiPaginator;
 
 class GameHistoryListData extends Data {
   public $gameHistories;
   public $gameHistoryTotalCount;
 
-  public function __construct(array $sources, int $count)
+  public function __construct(array $sources, ApiPaginator $apiPaginator)
   {
     $response = [];
     foreach ($sources as $source) {
@@ -28,7 +29,7 @@ class GameHistoryListData extends Data {
     }
 
     $this->gameHistories = $response;
-    $this->gameHistoryTotalCount = $count;
+		$this->paginator = $apiPaginator->getPaginator();
   }
 
   private function toPlayerMemories(array $sources): array

--- a/backend/package/Usecase/Player/ListHistory/PlayerListHistoryData.php
+++ b/backend/package/Usecase/Player/ListHistory/PlayerListHistoryData.php
@@ -3,6 +3,7 @@
 namespace Package\Usecase\Player\ListHistory;
 
 use Package\Usecase\Data;
+use Package\Domain\System\Entity\ApiPaginator;
 
 /**
  * Data Transfer Object
@@ -12,7 +13,7 @@ class PlayerListHistoryData extends Data
 	public $playerHistories;
 	public $playerHistoryTotalCount;
 
-	public function __construct(array $sources, int $count)
+	public function __construct(array $sources, ApiPaginator $apiPaginator)
 	{
 		$response = [];
 		foreach ($sources as $source) {
@@ -32,7 +33,7 @@ class PlayerListHistoryData extends Data
 		}
 
 		$this->playerHistories = $response;
-		$this->playerHistoryTotalCount = $count;
+		$this->paginator = $apiPaginator->getPaginator();
 	}
 
 	private function toPlayerMemories(array $playerMemories): array


### PR DESCRIPTION
close #65 

全ユーザ対戦履歴、個別対戦履歴のAPIレスポンスに以下の情報を返すようにしました。
- 対象のURI
  - /api/game/history/list
  - /api/player/history/{userId}
```
        "paginator": {
            "pref": 1,
            "current": 1,
            "next": 2,
            "totalCount": 599,
            "totalPage": 60,
            "limit": 10
        }
```