### PR TITLE
[WIP] [管理ページ] ユーザ一覧取得

### DIFF
--- a/backend/app/Http/Controllers/AdminController.php
+++ b/backend/app/Http/Controllers/AdminController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Admin\RegisterRequestUpdateRequest;
 use Package\Usecase\Admin\RegisterRequest\GetList\AdminRegisterRequestGetListServiceInterface;
 use Package\Usecase\Admin\RegisterRequest\Update\AdminRegisterRequestUpdateServiceInterface;
 use Package\Usecase\Admin\RegisterRequest\Update\AdminRegisterRequestUpdateCommand;
+use Package\Usecase\Admin\User\ListData\AdminUserListServiceInterface;
 
 class AdminController extends Controller
 {
@@ -28,5 +29,11 @@ class AdminController extends Controller
         ));
 
         return $this->validResponse($result, '新規登録リクエストを更新しました。');
+    }
+
+    public function listUser(AdminUserListServiceInterface $interactor)
+    {
+        $result = $interactor->handle();
+        return $this->validResponse($result->getVars(), '取得しました。');
     }
 }

--- a/backend/app/Http/Middleware/Authenticate.php
+++ b/backend/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,6 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
-            return route('login');
-        }
+        //
     }
 }

--- a/backend/app/Models/UserModel.php
+++ b/backend/app/Models/UserModel.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/backend/app/Providers/ApplicationProvider.php
+++ b/backend/app/Providers/ApplicationProvider.php
@@ -100,6 +100,10 @@ class ApplicationProvider extends ServiceProvider
             \Package\Usecase\Account\Game\StatusUpdate\AccountGameStatusUpdateServiceInterface::class,
             \Package\Application\Account\Game\StatusUpdate\AccountGameStatusUpdateService::class
         );
+        $this->app->bind(
+            \Package\Usecase\Admin\User\ListData\AdminUserListServiceInterface::class,
+            \Package\Application\Admin\User\ListData\AdminUserListService::class
+        );
     }
 
     /**

--- a/backend/package/Application/Admin/User/ListData/AdminUserListService.php
+++ b/backend/package/Application/Admin/User/ListData/AdminUserListService.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Package\Application\Admin\User\ListData;
+
+use Package\Usecase\Admin\User\ListData\AdminUserListServiceInterface;
+use Package\Usecase\Admin\User\ListData\AdminUserListData;
+
+class AdminUserListService implements AdminUserListServiceInterface {
+    public function __construct()
+    {
+        //
+    }
+
+    public function handle(): AdminUserListData
+    {
+        return new AdminUserListData([]);
+    }
+}

--- a/backend/package/Usecase/Admin/User/ListData/AdminUserListData.php
+++ b/backend/package/Usecase/Admin/User/ListData/AdminUserListData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Package\Usecase\Admin\User\ListData;
+
+use Package\Usecase\Data;
+
+/**
+ * Data Transfer Object
+ */
+
+class AdminUserListData extends Data {
+  public $users;
+
+  public function __construct(array $sources)
+  {
+      $this->users = [];
+  }
+}

--- a/backend/package/Usecase/Admin/User/ListData/AdminUserListServiceInterface.php
+++ b/backend/package/Usecase/Admin/User/ListData/AdminUserListServiceInterface.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Package\Usecase\Admin\User\ListData;
+
+interface AdminUserListServiceInterface {
+  public function handle(): AdminUserListData;
+}

--- a/backend/routes/Api/Authentication/AdminRoutes.php
+++ b/backend/routes/Api/Authentication/AdminRoutes.php
@@ -22,6 +22,12 @@ class AdminRoutes {
             Route::post('request/{registerId}', [AdminController::class, 'updateNewCreateRequest'])
             ->name('admin.request.update')
             ->where('registerId', '^[0-9]+$');
+
+            /**
+             * ユーザ一覧取得
+             * GET /api/admin/user
+             */
+            Route::get('user', [AdminController::class, 'listUser'])->name('admin.user');
         });
 	}
 }


### PR DESCRIPTION
ref #61

## 実装
ユーザ一覧取得
```
GET /api/admin/user
```
管理者がユーザを管理するために使用。
ステータス変更（BANなど）、レート変更なども行える。